### PR TITLE
Add tuple return support to useMemo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Current state is now provided to callback function when using `useState(function)`
-- useMemo can now return tuples
+- useMemo now supports tuple return values
 
 ## [0.1.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Current state is now provided to callback function when using `useState(function)`
-- useMemo now supports tuple return values
+- useMemo now supports tuple return values.
 
 ## [0.1.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Current state is now provided to callback function when using `useState(function)`
+- useMemo can now return tuples
 
 ## [0.1.1]
 ### Fixed

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -23,7 +23,7 @@ local function createUseMemo(useValue)
 			}
 		end
 
-		return unpack(currentValue.value.memoizedValue) or nil
+		return unpack(currentValue.value.memoizedValue)
 	end
 end
 

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -19,7 +19,7 @@ local function createUseMemo(useValue)
 		if needToRecalculate then
 			currentValue.value = {
 				dependencies = dependencies,
-				memoizedValue = {createValue()},
+				memoizedValue = { createValue() },
 			}
 		end
 

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -19,11 +19,11 @@ local function createUseMemo(useValue)
 		if needToRecalculate then
 			currentValue.value = {
 				dependencies = dependencies,
-				memoizedValue = createValue(),
+				memoizedValue = {createValue()},
 			}
 		end
 
-		return currentValue.value.memoizedValue
+		return unpack(currentValue.value.memoizedValue) or nil
 	end
 end
 


### PR DESCRIPTION
Functions that returns a tuple only retuns the first value when using `useMemo`
```lua
local function foo()
    return 1, 2
end

local v1, v2 = useMemo(foo) -- 1, nil
```

Would need to store the returned tuple in a table and then unpack it as a workaround:
```lua
local v1, v2 = unpack(useMemo(function()
    return {foo()}
end)) -- 1, 2
```