### PR TITLE
Fix `setState` nil callback parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fixed setState's parameter not being the state value when passing a callback to it.
+
 ## [0.2.0]
 ### Added
 - Added validateProps component API option for hooked components. `validateProps(props) -> (false, message: string) | true`

--- a/src/createUseState.lua
+++ b/src/createUseState.lua
@@ -22,8 +22,8 @@ local function createUseState(component)
 			value = nil
 		end
 		
-		table.insert(component.state, value)
-
+		component.state[hookCount] = value
+		
 		local setValue = setValues[hookCount]
 		if setValue == nil then
 			setValue = function(newValue)

--- a/src/createUseState.lua
+++ b/src/createUseState.lua
@@ -21,6 +21,8 @@ local function createUseState(component)
 		elseif value == NONE then
 			value = nil
 		end
+		
+		table.insert(component.state, value)
 
 		local setValue = setValues[hookCount]
 		if setValue == nil then


### PR DESCRIPTION
This fixes `setState`'s parameter not having its default value when passing a callback to it.
![image](https://user-images.githubusercontent.com/46044567/130369734-31bd27a6-fd65-4c84-bab4-2bb5dd7fa699.png)