### PR TITLE
Add Luau types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added Luau types to Hooks API ([#36](https://github.com/Kampfkarren/roact-hooks/pull/36))
+
 ## [0.4.1]
 ### Fixed
 - Fixed `useMemo` not working correctly with nil dependencies ([#35](https://github.com/Kampfkarren/roact-hooks/issues/35))

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Defines default values for props to ensure props will have values even if they w
 ## Implemented Hooks
 
 ### useState
-`useState<T>(defaultValue: T | () -> T) -> (T, update: (value: T | ((prevState: T) -> T)) -> ())`
+`useState<T>(defaultValue: T | (() -> T)) -> (T, update: (value: T | ((prevState: T) -> T)) -> ())`
 
 Used to store a stateful value. Returns the current value, and a function that can be used to set the value.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Defines default values for props to ensure props will have values even if they w
 ## Implemented Hooks
 
 ### useState
-`useState<T>(defaultValue: T) -> (T, update: (newValue: T) -> void)`
+`useState<T>(defaultValue: T | () -> T) -> (T, update: (value: T | ((prevState: T) -> T)) -> ())`
 
 Used to store a stateful value. Returns the current value, and a function that can be used to set the value.
 

--- a/src/createUseBinding.lua
+++ b/src/createUseBinding.lua
@@ -1,5 +1,5 @@
 local function createUseBinding(roact, useValue)
-	return function(defaultValue)
+	return function<T>(defaultValue: T): (any, (newValue: T) -> ())
 		return unpack(useValue({
 			roact.createBinding(defaultValue)
 		}).value)

--- a/src/createUseCallback.lua
+++ b/src/createUseCallback.lua
@@ -1,5 +1,8 @@
+type DependencyList = { unknown }
+type Function<Args..., Rets...> = (Args...) -> Rets...
+
 local function createUseCallback(useMemo)
-	return function(callback, dependencies)
+	return function<Args..., Rets...>(callback: Function<Args..., Rets...>, dependencies: DependencyList?): Function<Args..., Rets...>
 		return useMemo(function()
 			return callback
 		end, dependencies)

--- a/src/createUseEffect.lua
+++ b/src/createUseEffect.lua
@@ -1,5 +1,5 @@
 type Destructor = () -> ()
-type EffectCallback = () -> Destructor?
+type EffectCallback = (() -> Destructor) | (() -> ())
 type DependencyList = { unknown }
 
 local function createUseEffect(component)

--- a/src/createUseEffect.lua
+++ b/src/createUseEffect.lua
@@ -1,5 +1,9 @@
+type Destructor = () -> ()
+type EffectCallback = () -> Destructor?
+type DependencyList = { unknown }
+
 local function createUseEffect(component)
-	return function(callback, dependsOn)
+	return function(callback: EffectCallback, dependsOn: DependencyList?)
 		assert(typeof(callback) == "function", "useEffect callback is not a function")
 
 		component.hookCounter += 1

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -1,7 +1,10 @@
 local dependenciesDifferent = require(script.Parent.dependenciesDifferent)
 
+type DependencyList = { unknown }
+type Function<Args..., Rets...> = (Args...) -> Rets...
+
 local function createUseMemo(useValue)
-	return function(createValue, dependencies)
+	return function<T...>(createValue: () -> T..., dependencies: DependencyList?): T...
 		local currentValue = useValue(nil)
 
 		local needToRecalculate = dependencies == nil

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -1,7 +1,6 @@
 local dependenciesDifferent = require(script.Parent.dependenciesDifferent)
 
 type DependencyList = { unknown }
-type Function<Args..., Rets...> = (Args...) -> Rets...
 
 local function createUseMemo(useValue)
 	return function<T...>(createValue: () -> T..., dependencies: DependencyList?): T...

--- a/src/createUseReducer.lua
+++ b/src/createUseReducer.lua
@@ -1,5 +1,7 @@
+type Reducer<S, A> = (state: S, action: A) -> S
+
 local function createUseReducer(useCallback, useState)
-	return function(reducer, initialState)
+	return function<S, A>(reducer: Reducer<S, A>, initialState: S): (S, (action: A) -> ())
 		local state, setState = useState(initialState)
 		local dispatch = useCallback(function(action)
 			setState(reducer(state, action))

--- a/src/createUseState.lua
+++ b/src/createUseState.lua
@@ -8,10 +8,13 @@ local function extractValue(valueOrCallback, currentValue)
 	end
 end
 
+type SetStateAction<S> = S | ((prevState: S) -> S)
+type Dispatch<T> = (value: T) -> ()
+
 local function createUseState(component)
 	local setValues = {}
 
-	return function<T>(defaultValue: T): (T, (newValue: T) -> ())
+	return function<T>(defaultValue: T | (() -> T)): (T, Dispatch<SetStateAction<T>>)
 		component.hookCounter += 1
 		local hookCount = component.hookCounter
 		local value = component.state[hookCount]

--- a/src/createUseState.lua
+++ b/src/createUseState.lua
@@ -11,7 +11,7 @@ end
 local function createUseState(component)
 	local setValues = {}
 
-	return function(defaultValue)
+	return function<T>(defaultValue: T): (T, (newValue: T) -> ())
 		component.hookCounter += 1
 		local hookCount = component.hookCounter
 		local value = component.state[hookCount]

--- a/src/init.lua
+++ b/src/init.lua
@@ -42,6 +42,7 @@ export type HookOptions<Props> = {
 	defaultProps: { [string]: any }?,
 	componentType: string?,
 	validateProps: ((props: Props) -> (boolean, string?))?,
+	[string]: { NO_EXTRA_ARGS: never },
 }
 export type RenderFunction<Props> = (props: Props, hooks: Hooks) -> any
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -40,7 +40,7 @@ export type Hooks = typeof(createHooks())
 export type HookOptions<Props> = {
 	name: string?,
 	defaultProps: { [string]: any }?,
-	componentType: string?,
+	componentType: "Component" | "PureComponent" | nil,
 	validateProps: ((props: Props) -> (boolean, string?))?,
 	[string]: { NO_EXTRA_ARGS: never },
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -36,8 +36,17 @@ local function createHooks(roact, component)
 	}
 end
 
-function Hooks.new(roact)
-	return function(render, options)
+export type Hooks = typeof(createHooks())
+export type HookOptions<Props> = {
+	name: string?,
+	defaultProps: { [string]: any }?,
+	componentType: string?,
+	validateProps: ((props: Props) -> (boolean, string?))?,
+}
+export type RenderFunction<Props> = (props: Props, hooks: Hooks) -> any
+
+function Hooks.new<Props>(roact)
+	return function(render: RenderFunction<Props>, options: HookOptions<Props>?)
 		assert(typeof(render) == "function", "Hooked components must be functions.")
 
 		if options == nil then


### PR DESCRIPTION
Adds Luau types to (most) of the functions.

This is best effort, some things cannot currently be typed (correctly) yet, but we cover the most common uses. This shouldn't emit any false positives.

The following types are exported:
- `Hooks`, the second parameter of a functional component. Contains useState etc.
- `RenderFunction<Props>`, the functional component which has been "hook-ified"
- `HookOptions<Props>`, the options passed in Hooks.new

defined as
```lua
export type Hooks = -- inferred --
export type HookOptions<Props> = {
	name: string?,
	defaultProps: { [string]: any }?,
	componentType: string?,
	validateProps: ((props: Props) -> (boolean, string?))?,
	[string]: { NO_EXTRA_ARGS: never },
}
export type RenderFunction<Props> = (props: Props, hooks: Hooks) -> any
```

The following are now correctly typed:
- The functional component passed to `Hooks.new(Roact)(component, options)`: it takes props and hooks, and should return one value [we currently cannot enforce that one value is a RoactComponent]
- The options passed to the above
- `useState`
- `useEffect`
- `useValue` (auto inferred type)
- `useCallback`
- `useMemo`
- `useReducer`

useContext, useBinding and Roact are unfortunately not currently typed as we do not have enough info about them.

Adding these types provide improved intellisense when using Luau LSP / Roblox Studio

<details>
<summary>Example Screenshots</summary>

![image](https://user-images.githubusercontent.com/19635171/179359813-acc62022-ac53-4101-ba45-77e3dc4b7458.png)
![image](https://user-images.githubusercontent.com/19635171/179359820-b3a2f3a8-d712-41b1-bc1f-610250739c3b.png)
![image](https://user-images.githubusercontent.com/19635171/179359825-6279bb5e-bc5a-4d5a-a91b-9547c8f6ad57.png)
![image](https://user-images.githubusercontent.com/19635171/179359833-af3b1459-162d-463e-9db9-f0cefdc15f10.png)
![image](https://user-images.githubusercontent.com/19635171/179360073-e4bf0f74-8512-4257-be05-7cc8a92e41e7.png)

</details>