### PR TITLE
Update useContext to provide the default value

### DIFF
--- a/src/createUseContext.lua
+++ b/src/createUseContext.lua
@@ -7,20 +7,32 @@ local function createUseContext(component, useEffect, useState)
 	})
 
 	return function(context)
+		local defaultValue
+
+		fakeConsumer.props = {
+			render = function(value)
+				defaultValue = value
+			end,
+		}
+
 		context.Consumer.init(fakeConsumer)
+		context.Consumer.render(fakeConsumer)
 
 		local contextEntry = fakeConsumer.contextEntry
-		local value, setValue = useState(if contextEntry == nil then nil else contextEntry.value)
+		local value, setValue = useState(if contextEntry == nil then defaultValue else contextEntry.value)
 
 		useEffect(function()
 			if contextEntry == nil then
+				if value ~= defaultValue then
+					setValue(defaultValue)
+				end
 				return
 			end
 
 			if value ~= contextEntry.value then
 				setValue(contextEntry.value)
 			end
-			
+
 			return contextEntry.onUpdate:subscribe(setValue)
 		end, { contextEntry })
 

--- a/src/createUseContext.lua
+++ b/src/createUseContext.lua
@@ -1,4 +1,4 @@
-local function createUseContext(component, useEffect, useState)
+local function createUseContext(component, useEffect, useState, useMemo)
 	-- HACK: I'd like to just use the values from the consumers directly.
 	-- However, we don't know what contexts to listen to until `useContext` is called.
 	-- Thus, we do this insanely unstable method for doing it. :)
@@ -7,16 +7,20 @@ local function createUseContext(component, useEffect, useState)
 	})
 
 	return function(context)
-		local defaultValue
+		local defaultValue = useMemo(function()
+			local initialValue
 
-		fakeConsumer.props = {
-			render = function(value)
-				defaultValue = value
-			end,
-		}
+			fakeConsumer.props = {
+				render = function(value)
+					initialValue = value
+				end,
+			}
+
+			context.Consumer.render(fakeConsumer)
+			return initialValue
+		end, {})
 
 		context.Consumer.init(fakeConsumer)
-		context.Consumer.render(fakeConsumer)
 
 		local contextEntry = fakeConsumer.contextEntry
 		local value, setValue = useState(if contextEntry == nil then defaultValue else contextEntry.value)

--- a/src/init.lua
+++ b/src/init.lua
@@ -16,9 +16,9 @@ local function createHooks(roact, component)
 	local useValue = createUseValue(component)
 
 	local useBinding = createUseBinding(roact, useValue)
-	local useContext = createUseContext(component, useEffect, useState)
 	local useMemo = createUseMemo(useValue)
 
+	local useContext = createUseContext(component, useEffect, useState, useMemo)
 	local useCallback = createUseCallback(useMemo)
 
 	local useReducer = createUseReducer(useCallback, useState)


### PR DESCRIPTION
Adds the capability of providing the default value of a context to match the behavior of using contexts without hooks.

This resolves #14.